### PR TITLE
Fix incorrect handling of multi-message receives

### DIFF
--- a/mcumgr-smp/src/application_management.rs
+++ b/mcumgr-smp/src/application_management.rs
@@ -117,8 +117,8 @@ pub struct ImageWriter<'s> {
     pub sequence: u8,
 }
 
-impl<'s> ImageWriter<'s> {
-    pub fn new(image: Option<u8>, len: usize, hash: Option<&'s [u8]>) -> ImageWriter {
+impl ImageWriter<'_> {
+    pub fn new(image: Option<u8>, len: usize, hash: Option<&[u8]>) -> ImageWriter {
         ImageWriter {
             image,
             hash,
@@ -128,7 +128,7 @@ impl<'s> ImageWriter<'s> {
         }
     }
 
-    pub fn write_chunk<'d>(&mut self, data: &'d [u8]) -> SmpFrame<ImageChunk<'d, 's>> {
+    pub fn write_chunk<'d>(&mut self, data: &'d [u8]) -> SmpFrame<ImageChunk<'d, '_>> {
         let data_len = data.len();
 
         let mut chunk_data = ImageChunk {

--- a/mcumgr-smp/src/transport/smp_framing.rs
+++ b/mcumgr-smp/src/transport/smp_framing.rs
@@ -81,7 +81,7 @@ impl SmpTransportDecoder {
     }
 
     pub fn is_complete(&self) -> bool {
-        self.content_length != 0 && self.content_length as usize >= self.buf.len()
+        self.content_length != 0 && self.buf.len() >= self.content_length as usize
     }
 
     pub fn into_frame_payload(self) -> Result<Vec<u8>, SmpTransportError> {


### PR DESCRIPTION
Most of the changes are some minor fixes of formatting and warnings.

The actual fix is to change this:
```rust
self.content_length != 0 && self.content_length as usize >= self.buf.len()
```

to this:
```rust
self.content_length != 0 && self.buf.len() >= self.content_length as usize
```