### PR TITLE
Add retry, verify and upgrade-only mechanisms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add [`upgrade`](https://docs.zephyrproject.org/latest/services/device_mgmt/smp_groups/smp_group_1.html#image-upload-request) flag to image upload request
 - Add parsing of [`rsn`](https://docs.zephyrproject.org/latest/services/device_mgmt/smp_groups/smp_group_1.html#image-upload-response) error string fields where applicable
 - Add parsing of [`match`](https://docs.zephyrproject.org/latest/services/device_mgmt/smp_groups/smp_group_1.html#image-upload-response) field of image upload response, for on-device checksum verification
+- Add optional check for correct sequence number in `receive_cbor`/`transceive_cbor` functions
 
 ### Changed
 - Updated documentation to include info on the now included transports

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+- Add [`upgrade`](https://docs.zephyrproject.org/latest/services/device_mgmt/smp_groups/smp_group_1.html#image-upload-request) flag to image upload request
+- Add parsing of [`rsn`](https://docs.zephyrproject.org/latest/services/device_mgmt/smp_groups/smp_group_1.html#image-upload-response) error string fields where applicable
+- Add parsing of [`match`](https://docs.zephyrproject.org/latest/services/device_mgmt/smp_groups/smp_group_1.html#image-upload-response) field of image upload response, for on-device checksum verification
+
 ### Changed
 - Updated documentation to include info on the now included transports
+- Reduce default chunk size to `256` to match Zephyr's default
+- Take request data in `send_cbor` and `transceive_cbor` as reference, which allows users to implement a retry mechanism
+
+### Fixed
+- Fix broken messages after merging of multi-chunk responses
 
 ## [0.7.0] - 2024-09-05
 

--- a/mcumgr-smp/src/application_management.rs
+++ b/mcumgr-smp/src/application_management.rs
@@ -107,6 +107,8 @@ pub struct ImageChunk<'d, 's> {
     #[serde(with = "serde_bytes")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub sha: Option<&'s [u8]>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub upgrade: Option<bool>,
 }
 
 pub struct ImageWriter<'s> {
@@ -115,16 +117,18 @@ pub struct ImageWriter<'s> {
     pub offset: usize,
     pub len: usize,
     pub sequence: u8,
+    pub upgrade: bool,
 }
 
 impl ImageWriter<'_> {
-    pub fn new(image: Option<u8>, len: usize, hash: Option<&[u8]>) -> ImageWriter {
+    pub fn new(image: Option<u8>, len: usize, hash: Option<&[u8]>, upgrade: bool) -> ImageWriter {
         ImageWriter {
             image,
             hash,
             offset: 0,
             len,
             sequence: 0,
+            upgrade,
         }
     }
 
@@ -137,6 +141,7 @@ impl ImageWriter<'_> {
             image: None,
             len: None,
             sha: None,
+            upgrade: None,
         };
 
         if self.offset == 0 {
@@ -148,6 +153,10 @@ impl ImageWriter<'_> {
 
             if let Some(hash) = self.hash {
                 chunk_data.sha = Some(hash);
+            }
+
+            if self.upgrade {
+                chunk_data.upgrade = Some(true);
             }
         }
 

--- a/mcumgr-smp/src/application_management.rs
+++ b/mcumgr-smp/src/application_management.rs
@@ -184,6 +184,9 @@ pub enum WriteImageChunkResult {
 #[derive(Serialize, Deserialize, Debug)]
 pub struct WriteImageChunkPayload {
     pub off: u32,
+    #[serde(rename = "match")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub match_: Option<bool>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]

--- a/mcumgr-smp/src/application_management.rs
+++ b/mcumgr-smp/src/application_management.rs
@@ -40,6 +40,8 @@ pub struct GetImageStatePayload {
 #[derive(Serialize, Deserialize, Debug)]
 pub struct GetImageStateError {
     pub rc: i32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rsn: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -192,4 +194,6 @@ pub struct WriteImageChunkPayload {
 #[derive(Serialize, Deserialize, Debug)]
 pub struct WriteImageChunkError {
     pub rc: i32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rsn: Option<String>,
 }

--- a/mcumgr-smp/src/smp.rs
+++ b/mcumgr-smp/src/smp.rs
@@ -9,6 +9,8 @@ pub enum SmpError {
     PayloadDecodingError(#[from] Box<dyn std::error::Error>),
     #[error("smp frame decoding error")]
     InvalidFrame,
+    #[error("unexpected sequence number")]
+    UnexpectedSeq,
 }
 
 #[derive(Debug, Clone, Copy)]

--- a/mcumgr-smp/src/smp.rs
+++ b/mcumgr-smp/src/smp.rs
@@ -9,8 +9,6 @@ pub enum SmpError {
     PayloadDecodingError(#[from] Box<dyn std::error::Error>),
     #[error("smp frame decoding error")]
     InvalidFrame,
-    #[error("unexpected sequence number")]
-    UnexpectedSeq,
 }
 
 #[derive(Debug, Clone, Copy)]

--- a/mcumgr-smp/src/transport/smp/smp_async.rs
+++ b/mcumgr-smp/src/transport/smp/smp_async.rs
@@ -35,7 +35,7 @@ pub mod cbor {
 
         pub async fn send_cbor<T: serde::Serialize>(
             &mut self,
-            frame: SmpFrame<T>,
+            frame: &SmpFrame<T>,
         ) -> Result<(), Error> {
             let bytes = frame.encode_with_cbor();
             self.send(bytes).await
@@ -50,7 +50,7 @@ pub mod cbor {
 
         pub async fn transceive_cbor<Req: serde::Serialize, Resp: serde::de::DeserializeOwned>(
             &mut self,
-            frame: SmpFrame<Req>,
+            frame: &SmpFrame<Req>,
         ) -> Result<SmpFrame<Resp>, Error> {
             self.send_cbor(frame).await?;
             self.receive_cbor().await

--- a/mcumgr-smp/src/transport/smp/smp_async.rs
+++ b/mcumgr-smp/src/transport/smp/smp_async.rs
@@ -42,13 +42,9 @@ pub mod cbor {
         }
         pub async fn receive_cbor<T: serde::de::DeserializeOwned>(
             &mut self,
-            sequence: u8,
         ) -> Result<SmpFrame<T>, Error> {
             let bytes = self.receive().await?;
             let frame = SmpFrame::<T>::decode_with_cbor(&bytes)?;
-            if frame.sequence != sequence {
-                Err(Error::Smp(crate::SmpError::UnexpectedSeq))?;
-            }
             Ok(frame)
         }
 
@@ -57,7 +53,7 @@ pub mod cbor {
             frame: &SmpFrame<Req>,
         ) -> Result<SmpFrame<Resp>, Error> {
             self.send_cbor(frame).await?;
-            self.receive_cbor(frame.sequence).await
+            self.receive_cbor().await
         }
     }
 }

--- a/mcumgr-smp/src/transport/smp/smp_sync.rs
+++ b/mcumgr-smp/src/transport/smp/smp_sync.rs
@@ -31,7 +31,7 @@ pub mod cbor {
             self.transport.receive()
         }
 
-        pub fn send_cbor<T: serde::Serialize>(&mut self, frame: SmpFrame<T>) -> Result<(), Error> {
+        pub fn send_cbor<T: serde::Serialize>(&mut self, frame: &SmpFrame<T>) -> Result<(), Error> {
             let bytes = frame.encode_with_cbor();
             self.send(bytes)
         }
@@ -45,7 +45,7 @@ pub mod cbor {
 
         pub fn transceive_cbor<Req: serde::Serialize, Resp: serde::de::DeserializeOwned>(
             &mut self,
-            frame: SmpFrame<Req>,
+            frame: &SmpFrame<Req>,
         ) -> Result<SmpFrame<Resp>, Error> {
             self.send_cbor(frame)?;
             self.receive_cbor()

--- a/mcumgr-smp/src/transport/smp/smp_sync.rs
+++ b/mcumgr-smp/src/transport/smp/smp_sync.rs
@@ -37,9 +37,13 @@ pub mod cbor {
         }
         pub fn receive_cbor<T: serde::de::DeserializeOwned>(
             &mut self,
+            sequence: u8,
         ) -> Result<SmpFrame<T>, Error> {
             let bytes = self.receive()?;
             let frame = SmpFrame::<T>::decode_with_cbor(&bytes)?;
+            if frame.sequence != sequence {
+                Err(Error::Smp(crate::SmpError::UnexpectedSeq))?;
+            }
             Ok(frame)
         }
 
@@ -48,7 +52,7 @@ pub mod cbor {
             frame: &SmpFrame<Req>,
         ) -> Result<SmpFrame<Resp>, Error> {
             self.send_cbor(frame)?;
-            self.receive_cbor()
+            self.receive_cbor(frame.sequence)
         }
     }
 }

--- a/mcumgr-smp/src/transport/smp/smp_sync.rs
+++ b/mcumgr-smp/src/transport/smp/smp_sync.rs
@@ -37,13 +37,9 @@ pub mod cbor {
         }
         pub fn receive_cbor<T: serde::de::DeserializeOwned>(
             &mut self,
-            sequence: u8,
         ) -> Result<SmpFrame<T>, Error> {
             let bytes = self.receive()?;
             let frame = SmpFrame::<T>::decode_with_cbor(&bytes)?;
-            if frame.sequence != sequence {
-                Err(Error::Smp(crate::SmpError::UnexpectedSeq))?;
-            }
             Ok(frame)
         }
 
@@ -52,7 +48,7 @@ pub mod cbor {
             frame: &SmpFrame<Req>,
         ) -> Result<SmpFrame<Resp>, Error> {
             self.send_cbor(frame)?;
-            self.receive_cbor(frame.sequence)
+            self.receive_cbor()
         }
     }
 }

--- a/mcumgr-smp/src/transport/smp/smp_sync.rs
+++ b/mcumgr-smp/src/transport/smp/smp_sync.rs
@@ -37,18 +37,25 @@ pub mod cbor {
         }
         pub fn receive_cbor<T: serde::de::DeserializeOwned>(
             &mut self,
+            expected_sequence: Option<u8>,
         ) -> Result<SmpFrame<T>, Error> {
             let bytes = self.receive()?;
             let frame = SmpFrame::<T>::decode_with_cbor(&bytes)?;
+            if let Some(expected_sequence) = expected_sequence {
+                if frame.sequence != expected_sequence {
+                    Err(Error::Smp(crate::SmpError::UnexpectedSeq))?;
+                }
+            }
             Ok(frame)
         }
 
         pub fn transceive_cbor<Req: serde::Serialize, Resp: serde::de::DeserializeOwned>(
             &mut self,
             frame: &SmpFrame<Req>,
+            check_sequence: bool,
         ) -> Result<SmpFrame<Resp>, Error> {
             self.send_cbor(frame)?;
-            self.receive_cbor()
+            self.receive_cbor(check_sequence.then_some(frame.sequence))
         }
     }
 }

--- a/smp-tool/src/main.rs
+++ b/smp-tool/src/main.rs
@@ -226,7 +226,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
             hasher.update(&firmware);
             let hash = hasher.finalize();
 
-            debug!("Image sha256: {:02X?}", hash);
+            println!("Image sha256: {:x}", hash);
 
             let mut updater = mcumgr_smp::application_management::ImageWriter::new(
                 slot,

--- a/smp-tool/src/main.rs
+++ b/smp-tool/src/main.rs
@@ -305,6 +305,9 @@ async fn main() -> Result<(), Box<dyn Error>> {
                 }
                 GetImageStateResult::Err(err) => {
                     eprintln!("rc: {}", err.rc);
+                    if let Some(msg) = err.rsn {
+                        eprintln!("rsn: {:?}", msg);
+                    }
                 }
             }
         }

--- a/smp-tool/src/main.rs
+++ b/smp-tool/src/main.rs
@@ -112,8 +112,6 @@ enum ApplicationCmd {
         /// Only allow newer firmware versions
         #[arg(long)]
         upgrade: bool,
-        #[arg(long)]
-        verify: bool,
     },
 }
 
@@ -221,7 +219,6 @@ async fn main() -> Result<(), Box<dyn Error>> {
             update_file,
             chunk_size,
             upgrade,
-            verify,
         }) => {
             let firmware = std::fs::read(&update_file)?;
 
@@ -263,17 +260,11 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
             println!("sent all bytes: {}", offset);
 
-            match verified {
-                Some(true) => {
+            if let Some(verified) = verified {
+                if verified {
                     println!("Image verified");
-                }
-                Some(false) => Err("Image verification failed!".to_string())?,
-                None => {
-                    if verify {
-                        Err("Device did not deliver verification data".to_string())?
-                    } else {
-                        println!("No image verification data available.");
-                    }
+                } else {
+                    eprintln!("Image verification failed!");
                 }
             }
         }

--- a/smp-tool/src/main.rs
+++ b/smp-tool/src/main.rs
@@ -109,6 +109,8 @@ enum ApplicationCmd {
         update_file: PathBuf,
         #[arg(short, long, default_value_t = 512)]
         chunk_size: usize,
+        #[arg(long)]
+        upgrade: bool,
     },
 }
 
@@ -215,6 +217,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
             slot,
             update_file,
             chunk_size,
+            upgrade,
         }) => {
             let firmware = std::fs::read(&update_file)?;
 
@@ -228,6 +231,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                 slot,
                 firmware.len(),
                 Some(&hash),
+                upgrade,
             );
 
             let mut offset = 0;

--- a/smp-tool/src/main.rs
+++ b/smp-tool/src/main.rs
@@ -103,12 +103,13 @@ enum ApplicationCmd {
     // },
     /// Flash a firmware to an image slot
     Flash {
+        #[arg()]
+        update_file: PathBuf,
         #[arg(short, long)]
         slot: Option<u8>,
-        #[arg(short, long)]
-        update_file: PathBuf,
-        #[arg(short, long, default_value_t = 512)]
+        #[arg(short, long, default_value_t = 256)]
         chunk_size: usize,
+        /// Only allow newer firmware versions
         #[arg(long)]
         upgrade: bool,
     },

--- a/smp-tool/src/main.rs
+++ b/smp-tool/src/main.rs
@@ -128,8 +128,8 @@ impl UsedTransport {
         frame: SmpFrame<Req>,
     ) -> Result<SmpFrame<Resp>, mcumgr_smp::transport::error::Error> {
         match self {
-            UsedTransport::SyncTransport(ref mut t) => t.transceive_cbor(&frame),
-            UsedTransport::AsyncTransport(ref mut t) => t.transceive_cbor(&frame).await,
+            UsedTransport::SyncTransport(ref mut t) => t.transceive_cbor(&frame, false),
+            UsedTransport::AsyncTransport(ref mut t) => t.transceive_cbor(&frame, false).await,
         }
     }
 }

--- a/smp-tool/src/main.rs
+++ b/smp-tool/src/main.rs
@@ -125,11 +125,11 @@ pub enum UsedTransport {
 impl UsedTransport {
     pub async fn transceive_cbor<Req: serde::Serialize, Resp: serde::de::DeserializeOwned>(
         &mut self,
-        frame: SmpFrame<Req>,
+        frame: &SmpFrame<Req>,
     ) -> Result<SmpFrame<Resp>, mcumgr_smp::transport::error::Error> {
         match self {
-            UsedTransport::SyncTransport(ref mut t) => t.transceive_cbor(&frame, false),
-            UsedTransport::AsyncTransport(ref mut t) => t.transceive_cbor(&frame, false).await,
+            UsedTransport::SyncTransport(ref mut t) => t.transceive_cbor(frame, false),
+            UsedTransport::AsyncTransport(ref mut t) => t.transceive_cbor(frame, false).await,
         }
     }
 }
@@ -185,7 +185,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     match cli.command {
         Commands::Os(OsCmd::Echo { msg }) => {
             let ret: SmpFrame<EchoResult> = transport
-                .transceive_cbor(os_management::echo(42, msg))
+                .transceive_cbor(&os_management::echo(42, msg))
                 .await?;
             debug!("{:?}", ret);
 
@@ -200,7 +200,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         }
         Commands::Shell(ShellCmd::Exec { cmd }) => {
             let ret: SmpFrame<ShellResult> = transport
-                .transceive_cbor(shell_management::shell_command(42, cmd))
+                .transceive_cbor(&shell_management::shell_command(42, cmd))
                 .await?;
             debug!("{:?}", ret);
 
@@ -246,7 +246,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                 let chunk = &firmware[offset..min(firmware.len(), offset + chunk_size)];
 
                 let resp_frame: SmpFrame<WriteImageChunkResult> = transport
-                    .transceive_cbor(updater.write_chunk(chunk))
+                    .transceive_cbor(&updater.write_chunk(chunk))
                     .await?;
 
                 match resp_frame.data {
@@ -279,7 +279,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         }
         Commands::App(ApplicationCmd::Info) => {
             let ret: SmpFrame<GetImageStateResult> = transport
-                .transceive_cbor(application_management::get_state(42))
+                .transceive_cbor(&application_management::get_state(42))
                 .await?;
             debug!("{:?}", ret);
 

--- a/smp-tool/src/shell.rs
+++ b/smp-tool/src/shell.rs
@@ -34,7 +34,7 @@ pub async fn shell(transport: &mut UsedTransport) -> Result<(), Box<dyn Error>> 
                 let argv: Vec<_> = buffer.split_whitespace().map(|s| s.to_owned()).collect();
 
                 let ret: Result<SmpFrame<ShellResult>, _> = transport
-                    .transceive_cbor(shell_management::shell_command(42, argv))
+                    .transceive_cbor(shell_management::shell_command(42, argv), 0)
                     .await;
                 debug!("{:?}", ret);
 

--- a/smp-tool/src/shell.rs
+++ b/smp-tool/src/shell.rs
@@ -34,7 +34,7 @@ pub async fn shell(transport: &mut UsedTransport) -> Result<(), Box<dyn Error>> 
                 let argv: Vec<_> = buffer.split_whitespace().map(|s| s.to_owned()).collect();
 
                 let ret: Result<SmpFrame<ShellResult>, _> = transport
-                    .transceive_cbor(shell_management::shell_command(42, argv), 0)
+                    .transceive_cbor(shell_management::shell_command(42, argv))
                     .await;
                 debug!("{:?}", ret);
 

--- a/smp-tool/src/shell.rs
+++ b/smp-tool/src/shell.rs
@@ -34,7 +34,7 @@ pub async fn shell(transport: &mut UsedTransport) -> Result<(), Box<dyn Error>> 
                 let argv: Vec<_> = buffer.split_whitespace().map(|s| s.to_owned()).collect();
 
                 let ret: Result<SmpFrame<ShellResult>, _> = transport
-                    .transceive_cbor(shell_management::shell_command(42, argv))
+                    .transceive_cbor(&shell_management::shell_command(42, argv))
                     .await;
                 debug!("{:?}", ret);
 


### PR DESCRIPTION
- Upgrade only: A flag that exists in zephyr; if set, it checks on device side if the new firmware has a higher version number, and if not, rejects the upgrade.
- Retry: Firmware updates are very prone to package loss; therefore other tools like `mcumgr-smp` or `AuTerm` implement a retry mechanism that simply repeats the request if no answer was received. Seems to work. I have a very buggy USB connection (still trying to figure out why, might be an issue in Zephyr), but retries made it reliable.
  EDIT: Removed that mechanism from the CLI tool, but made the frame pass-by-reference so that the user of this crate can
  implement a retry mechanism.
- Reduce default MTU to 256, as this is the default value in Zephyr (512 simply crashes with Zephyr default settings)
- Check for correct image checksum on device (see `match` field of flash return value)
- Add rsn field for verbose errors