### PR TITLE
smp-tool: add option to confirm a transmitted image and to reboot the device

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,26 +6,32 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-No changes since 0.8.0
+
+- [smp-tool] add 'confirm' subcommand to 'app' command to confirm an image slot
+- [smp-tool] add 'reset' subcommand to 'os' command to trigger a firmware reboot
 
 ## [0.8.0] - 2025-01-08
 
 ### Added
+
 - Add [`upgrade`](https://docs.zephyrproject.org/latest/services/device_mgmt/smp_groups/smp_group_1.html#image-upload-request) flag to image upload request
 - Add parsing of [`rsn`](https://docs.zephyrproject.org/latest/services/device_mgmt/smp_groups/smp_group_1.html#image-upload-response) error string fields where applicable
 - Add parsing of [`match`](https://docs.zephyrproject.org/latest/services/device_mgmt/smp_groups/smp_group_1.html#image-upload-response) field of image upload response, for on-device checksum verification
 - Add optional check for correct sequence number in `receive_cbor`/`transceive_cbor` functions
 
 ### Changed
+
 - Updated documentation to include info on the now included transports
 - Reduce default chunk size to `256` to match Zephyr's default
 - Take request data in `send_cbor` and `transceive_cbor` as reference, which allows users to implement a retry mechanism
 - Update dependencies in Cargo.lock
 
 ### Fixed
+
 - Fix broken messages after merging of multi-chunk responses
 
 ### Removed
+
 - Unused `regex` dependency
 
 ## [0.7.0] - 2024-09-05

--- a/smp-tool/src/main.rs
+++ b/smp-tool/src/main.rs
@@ -113,6 +113,12 @@ enum ApplicationCmd {
         #[arg(long)]
         upgrade: bool,
     },
+    /// Confirm/activate an image slot (makes the image permanent after a test boot)
+    Confirm {
+        /// Image slot to confirm (0 = primary/active, 1 = secondary).
+        #[arg(short, long)]
+        slot: u8,
+    },
 }
 
 pub enum UsedTransport {
@@ -265,6 +271,40 @@ async fn main() -> Result<(), Box<dyn Error>> {
                     println!("Image verified");
                 } else {
                     eprintln!("Image verification failed!");
+                }
+            }
+        }
+        Commands::App(ApplicationCmd::Confirm { slot }) => {
+            let tlv_hash: Vec<u8> = {
+                let state_ret: SmpFrame<GetImageStateResult> = transport
+                    .transceive_cbor(&application_management::get_state(41))
+                    .await?;
+                match state_ret.data {
+                    GetImageStateResult::Ok(ref payload) => payload
+                        .images
+                        .iter()
+                        .find(|img| img.slot == slot as i32)
+                        .map(|img| img.hash.clone())
+                        .ok_or_else(|| format!("slot {} not found in image state", slot))?,
+                    GetImageStateResult::Err(err) => {
+                        return Err(format!("get_state error rc: {}", err.rc))?;
+                    }
+                }
+            };
+
+            let set_state = application_management::set_state(tlv_hash, true, 42);
+            let ret: SmpFrame<GetImageStateResult> = transport.transceive_cbor(&set_state).await?;
+
+            match ret.data {
+                GetImageStateResult::Ok(payload) => {
+                    println!("Image confirmed: {:?}", payload);
+                }
+                GetImageStateResult::Err(err) => {
+                    eprintln!(
+                        "confirm error rc: {} ({:?})",
+                        err.rc,
+                        err.rsn.unwrap_or("".into())
+                    );
                 }
             }
         }

--- a/smp-tool/src/main.rs
+++ b/smp-tool/src/main.rs
@@ -9,7 +9,7 @@ use std::time::Duration;
 use clap::{Parser, Subcommand, ValueEnum};
 use mcumgr_smp::{
     application_management::{self, GetImageStateResult, WriteImageChunkResult},
-    os_management::{self, EchoResult},
+    os_management::{self, EchoResult, ResetResult},
     shell_management::{self, ShellResult},
     smp::SmpFrame,
     transport::{
@@ -84,6 +84,11 @@ enum Commands {
 enum OsCmd {
     /// Send an SMP Echo request
     Echo { msg: String },
+    /// Send a SMP Reset request
+    Reset {
+        #[arg(short, long, default_value_t = false)]
+        force: bool,
+    },
 }
 #[derive(Subcommand, Debug)]
 enum ShellCmd {
@@ -198,6 +203,21 @@ async fn main() -> Result<(), Box<dyn Error>> {
                     println!("{}", r);
                 }
                 EchoResult::Err { rc } => {
+                    eprintln!("rc: {}", rc);
+                }
+            }
+        }
+        Commands::Os(OsCmd::Reset { force }) => {
+            let ret: SmpFrame<ResetResult> = transport
+                .transceive_cbor(&os_management::reset(42, force))
+                .await?;
+            debug!("{:?}", ret);
+
+            match ret.data {
+                ResetResult::Ok {} => {
+                    println!("Reset sent sucessfully");
+                }
+                ResetResult::Err { rc } => {
                     eprintln!("rc: {}", rc);
                 }
             }


### PR DESCRIPTION
This adds an option to the smp-tool's app command to set the confirmation-state of an image to true.
Therefore after a reboot a confirmed image in slot 1 will get activated.

A second commit also adds an option to trigger a reset.

This should resolve #11 